### PR TITLE
Add method for getting all parameters

### DIFF
--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -64,6 +64,12 @@ class Parameters:
             )
         return ret
 
+    def get_all(self, **kwargs):
+        all_params = {}
+        for param in self._validator_schema.fields:
+            all_params[param] = self.get(param, **kwargs)
+        return all_params
+
     def _update_param(self, param, new_values):
         curr_vals = getattr(self, param)["value"]
         for i in range(len(new_values)):

--- a/paramtools/tests/test_weather_ex.py
+++ b/paramtools/tests/test_weather_ex.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import pytest
 
@@ -59,6 +60,47 @@ def WeatherParams(schema_def_path, base_spec_path):
 
 def test_load_schema(revision, WeatherParams):
     params = WeatherParams()
+
+
+def test_get_all_parameters(WeatherParams, base_spec_path):
+    wp = WeatherParams()
+    params = wp.get_all()
+    assert set(params.keys()) == set(
+        ["average_high_temperature", "average_precipitation"]
+    )
+    with open(base_spec_path) as f:
+        exp = json.loads(f.read())
+    assert (
+        params["average_high_temperature"]
+        == exp["average_high_temperature"]["value"]
+    )
+    assert (
+        params["average_precipitation"]
+        == exp["average_precipitation"]["value"]
+    )
+
+    exp = {
+        "average_high_temperature": [
+            {
+                "value": 59,
+                "month": "November",
+                "city": "Washington, D.C.",
+                "dayofmonth": 1,
+            },
+            {
+                "value": 64,
+                "month": "November",
+                "city": "Atlanta, GA",
+                "dayofmonth": 1,
+            },
+        ],
+        "average_precipitation": [
+            {"value": 3.0, "month": "November", "city": "Washington, D.C."},
+            {"value": 3.6, "month": "November", "city": "Atlanta, GA"},
+        ],
+    }
+
+    assert wp.get_all(month="November") == exp
 
 
 def test_failed_udpate(WeatherParams):


### PR DESCRIPTION
This PR adds a method for querying all parameters.

```python
In [2]: from paramtools import parameters
   ...: from paramtools.utils import get_example_paths
   ...: 
   ...: # example weather parameters
   ...: project_schema, baseline_parameters = get_example_paths('weather')
   ...: 
   ...: class WeatherParams(parameters.Parameters):
   ...:     project_schema = project_schema
   ...:     baseline_parameters = baseline_parameters
   ...: 
   ...: params = WeatherParams()
   ...: 
   ...: 

In [3]: 

In [3]: params.get_all(month="November")
Out[3]: 
{'average_high_temperature': [{'value': 59,
   'month': 'November',
   'city': 'Washington, D.C.',
   'dayofmonth': 1},
  {'value': 64, 'month': 'November', 'city': 'Atlanta, GA', 'dayofmonth': 1}],
 'average_precipitation': [{'value': 3.0,
   'month': 'November',
   'city': 'Washington, D.C.'},
  {'value': 3.6, 'month': 'November', 'city': 'Atlanta, GA'}]}

In [4]:                                                                                                                                                                                                                                                                       
```