### PR TITLE
Pull all error messages from error dictionary 

### DIFF
--- a/paramtools/build_schema.py
+++ b/paramtools/build_schema.py
@@ -1,6 +1,10 @@
 from marshmallow import fields
 
-from paramtools.schema import EmptySchema, BaseValidatorSchema, get_param_schema
+from paramtools.schema import (
+    EmptySchema,
+    BaseValidatorSchema,
+    get_param_schema,
+)
 from paramtools import utils
 
 

--- a/paramtools/parameters.py
+++ b/paramtools/parameters.py
@@ -19,9 +19,7 @@ class Parameters:
     field_map = {}
 
     def __init__(self):
-        sb = SchemaBuilder(
-            self.schema, self.defaults, self.field_map
-        )
+        sb = SchemaBuilder(self.schema, self.defaults, self.field_map)
         defaults, self._validator_schema = sb.build_schemas()
         for k, v in defaults.items():
             setattr(self, k, v)

--- a/paramtools/tests/test_tc_ex.py
+++ b/paramtools/tests/test_tc_ex.py
@@ -122,13 +122,17 @@ def test_range_validation_on_named_variable_fails(TaxcalcParams):
 
 
 def test_range_validation_on_default_variable(TaxcalcParams):
-    adjustment = {"_STD": [{"year": 2018, "MARS": "separate", "value": 12001.00}]}
+    adjustment = {
+        "_STD": [{"year": 2018, "MARS": "separate", "value": 12001.00}]
+    }
     params = TaxcalcParams()
     params.adjust(adjustment)
 
 
 def test_range_validation_on_default_variable_fails(TaxcalcParams):
-    adjustment = {"_STD": [{"year": 2018, "MARS": "separate", "value": 11999.00}]}
+    adjustment = {
+        "_STD": [{"year": 2018, "MARS": "separate", "value": 11999.00}]
+    }
     params = TaxcalcParams()
     with pytest.raises(exceptions.ValidationError) as excinfo:
         params.adjust(adjustment)

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,0 +1,6 @@
+from paramtools import utils
+
+def test_get_leaves():
+    t = {0: {'value': {0: ['leaf1', 'leaf2']}}}
+    r = utils.get_leaves(t)
+    assert r == ['leaf1', 'leaf2']

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -10,25 +10,17 @@ def test_get_leaves():
         },
     }
 
-    gl = utils.LeafGetter()
-    gl.get(t)
-    assert gl.leaves == [f"leaf{i}" for i in range(1, 9)]
+    leaves = utils.get_leaves(t)
+    assert leaves == [f"leaf{i}" for i in range(1, 9)]
 
-    gl = utils.LeafGetter()
-    gl.get([t])
-    assert gl.leaves == [f"leaf{i}" for i in range(1, 9)]
+    leaves = utils.get_leaves([t])
+    assert leaves == [f"leaf{i}" for i in range(1, 9)]
 
-    gl = utils.LeafGetter()
-    gl.get({})
-    assert gl.leaves == []
+    leaves = utils.get_leaves({})
+    assert leaves == []
 
-    gl = utils.LeafGetter()
-    gl.get([])
-    assert gl.leaves == []
+    leaves = utils.get_leaves([])
+    assert leaves == []
 
-    gl = utils.LeafGetter()
-    gl.get("leaf")
-    assert gl.leaves == ["leaf"]
-
-    gl.clear()
-    assert gl.leaves == []
+    leaves = utils.get_leaves("leaf")
+    assert leaves == ["leaf"]

--- a/paramtools/tests/test_utils.py
+++ b/paramtools/tests/test_utils.py
@@ -1,6 +1,34 @@
 from paramtools import utils
 
+
 def test_get_leaves():
-    t = {0: {'value': {0: ['leaf1', 'leaf2']}}}
-    r = utils.get_leaves(t)
-    assert r == ['leaf1', 'leaf2']
+    t = {
+        0: {"value": {0: ["leaf1", "leaf2"]}, 1: {"value": {0: ["leaf3"]}}},
+        1: {
+            "value": {1: ["leaf4", "leaf5"]},
+            2: {"value": {0: ["leaf6", ["leaf7", "leaf8"]]}},
+        },
+    }
+
+    gl = utils.LeafGetter()
+    gl.get(t)
+    assert gl.leaves == [f"leaf{i}" for i in range(1, 9)]
+
+    gl = utils.LeafGetter()
+    gl.get([t])
+    assert gl.leaves == [f"leaf{i}" for i in range(1, 9)]
+
+    gl = utils.LeafGetter()
+    gl.get({})
+    assert gl.leaves == []
+
+    gl = utils.LeafGetter()
+    gl.get([])
+    assert gl.leaves == []
+
+    gl = utils.LeafGetter()
+    gl.get("leaf")
+    assert gl.leaves == ["leaf"]
+
+    gl.clear()
+    assert gl.leaves == []

--- a/paramtools/tests/test_weather_ex.py
+++ b/paramtools/tests/test_weather_ex.py
@@ -52,8 +52,7 @@ def test_specification(WeatherParams, defaults_spec_path):
         == exp["average_high_temperature"]["value"]
     )
     assert (
-        spec["average_precipitation"]
-        == exp["average_precipitation"]["value"]
+        spec["average_precipitation"] == exp["average_precipitation"]["value"]
     )
 
     exp = {

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -66,5 +66,8 @@ class LeafGetter:
         else:
             self.leaves.append(item)
 
-    def clear(self):
-        self.leaves = []
+
+def get_leaves(item):
+    gl = LeafGetter()
+    gl.get(item)
+    return gl.leaves

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -42,16 +42,29 @@ def get_example_paths(name):
     return (schema_def_path, default_spec_path)
 
 
-def get_leaves(item):
+class LeafGetter:
     """
-    Return all values of a dictionary or the values of a list that
-    is a value of a dictionary.
+    Return all non-dict or non-list items of a given object. This object
+    should be an item or a list or dictionary composed of non-iterable items,
+    nested dictionaries or nested lists.
+
+    A functional approach was considered instead of this class. However, I was
+    unable to come up with a way to store all of the leaves without "cheating"
+    and keeping "leaf" state.
     """
-    if isinstance(item, dict):
-        for k, v in item.items():
-            return get_leaves(v)
-    elif isinstance(item, list):
-        for li in item:
-            return get_leaves(li)
-    else:
-        return item
+
+    def __init__(self):
+        self.leaves = []
+
+    def get(self, item):
+        if isinstance(item, dict):
+            for _, v in item.items():
+                self.get(v)
+        elif isinstance(item, list):
+            for li in item:
+                self.get(li)
+        else:
+            self.leaves.append(item)
+
+    def clear(self):
+        self.leaves = []

--- a/paramtools/utils.py
+++ b/paramtools/utils.py
@@ -40,3 +40,18 @@ def get_example_paths(name):
         current_path, f"../examples/{name}/defaults.json"
     )
     return (schema_def_path, default_spec_path)
+
+
+def get_leaves(item):
+    """
+    Return all values of a dictionary or the values of a list that
+    is a value of a dictionary.
+    """
+    if isinstance(item, dict):
+        for k, v in item.items():
+            return get_leaves(v)
+    elif isinstance(item, list):
+        for li in item:
+            return get_leaves(li)
+    else:
+        return item


### PR DESCRIPTION
`marshmallow` returns a dictionary of error messages which corresponds to the structure of the inputs dictionary. Thus, if the inputs dictionary was:

```python
{
    "inputs": ["good value", "bad value"],
}
```

the error dictionary would be something like:

```python
{
    "inputs": {1: "'bad value' not allowed!"} ,
}
```

This is somewhat helpful if you know how the inputs dictionary is structured. However, there are other situations where you don't really care what the inputs dictionary looks like--you just want the error messages.

One implementation comment that I noted int he `LeafGetter` docstring, a functional approach was considered instead of using a class. However, I was unable to come up with a way to store all of the leaves without "cheating" and keeping "leaf" state. In the future, I hope to replace this class with a functional approach...until then, `utils.get_leaves` can be used to wrap the `LeafGetter` class.